### PR TITLE
Create persistent subscription and projections on boot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-geteventstore",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Event Store connector for Nest js",
   "author": "Taimoor Alam <taimoor.alam@daypaio.com>",
   "contributors": [

--- a/src/event-store/event-store.class.ts
+++ b/src/event-store/event-store.class.ts
@@ -1,21 +1,16 @@
-import {
-  createConnection,
-  EventStoreNodeConnection,
-  ConnectionSettings,
-  TcpEndPoint,
-  expectedVersion,
-} from 'node-eventstore-client';
+import { createConnection, EventStoreNodeConnection, expectedVersion, TcpEndPoint } from 'node-eventstore-client';
 import * as geteventstorePromise from 'geteventstore-promise';
+import { HTTPClient } from 'geteventstore-promise';
 import { defer, from, throwError } from 'rxjs';
 import { Logger } from '@nestjs/common';
 import * as fp from 'lodash/fp';
-import { map, catchError, toArray, flatMap } from 'rxjs/operators';
+import { catchError, flatMap, map, toArray } from 'rxjs/operators';
 
 export class EventStore {
   connection: EventStoreNodeConnection;
   expectedVersion: any;
   isConnected: boolean = false;
-  HTTPClient: any;
+  HTTPClient: HTTPClient;
 
   private logger: Logger = new Logger(this.constructor.name);
   _addDefaultVersion: any;

--- a/src/event-store/eventstore-cqrs/event-bus.provider.ts
+++ b/src/event-store/eventstore-cqrs/event-bus.provider.ts
@@ -5,46 +5,11 @@ import { filter } from 'rxjs/operators';
 import { isFunction } from 'util';
 import { CommandBus, IEvent, IEventHandler, InvalidSagaException, ISaga, ObservableBus } from '@nestjs/cqrs';
 import { EVENTS_HANDLER_METADATA, SAGA_METADATA } from '@nestjs/cqrs/dist/decorators/constants';
-import { EventStoreBus, TAcknowledgeEventStoreEvent, TEventStoreEvent } from './event-store.bus';
 import { EventStore } from '../event-store.class';
 import { CqrsOptions } from '@nestjs/cqrs/dist/interfaces/cqrs-options.interface';
 
-export enum EventStoreSubscriptionType {
-  Persistent,
-  CatchUp,
-}
-
-export type EventStorePersistentSubscription = {
-  type: EventStoreSubscriptionType.Persistent;
-  stream: string;
-  group: string;
-  autoAck?: boolean | undefined;
-  bufferSize?: number | undefined;
-  onSubscriptionDropped?: (
-    sub: EventStorePersistentSubscription,
-    reason: string,
-    error: string,
-  ) => void | undefined;
-};
-
-export type EventStoreCatchupSubscription = {
-  type: EventStoreSubscriptionType.CatchUp;
-  stream: string;
-};
-
-export type EventStoreSubscriptionConfig = {
-  persistentSubscriptionName: string;
-};
-
-export type EventStoreSubscription =
-  | EventStorePersistentSubscription
-  | EventStoreCatchupSubscription;
-
-export type EventStoreBusConfig = {
-  // TODO init with projections and subscriptions to build
-  subscriptions: EventStoreSubscription[];
-  eventMapper: (event: TEventStoreEvent | TAcknowledgeEventStoreEvent) => IEvent;
-};
+import { EventStoreBus } from './event-store.bus';
+import { EventStoreBusConfig } from '../../interfaces/EventStoreBusConfig';
 
 export type EventHandlerType = Type<IEventHandler<IEvent>>;
 

--- a/src/event-store/eventstore-cqrs/eventstore-cqrs.module.ts
+++ b/src/event-store/eventstore-cqrs/eventstore-cqrs.module.ts
@@ -1,15 +1,13 @@
 import { CommandBus, EventBus, QueryBus } from '@nestjs/cqrs';
 import { DynamicModule, Global, Module } from '@nestjs/common';
-import { EventBusProvider, EventStoreBusConfig } from './event-bus.provider';
+import { EventBusProvider } from './event-bus.provider';
 import { EventStore } from '../event-store.class';
 import { ExplorerService } from '@nestjs/cqrs/dist/services/explorer.service';
 import { ModuleRef } from '@nestjs/core';
-import {
-  EventStoreModule,
-  EventStoreModuleAsyncOptions,
-} from '../event-store.module';
+import { EventStoreModule, EventStoreModuleAsyncOptions } from '../event-store.module';
 import { EventPublisher } from './event-publisher';
 import { EventStoreObserver } from '../event-store.observer';
+import { EventStoreBusConfig } from '../../interfaces/EventStoreBusConfig';
 
 @Global()
 @Module({})

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,4 @@ export * from './interfaces/IEventStoreConfig';
 export * from './interfaces/EventStoreBusConfig';
 export * from './interfaces/EventTypes';
 export * from './interfaces/SubscriptionTypes';
+export * from './interfaces/EventStoreProjection';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,6 @@ export * from './event-store/event-store.interceptor';
 export * from './event-store/eventstore-cqrs/event-store.bus';
 export * from './event-store/eventstore-cqrs/event-bus.provider';
 export * from './interfaces/IEventStoreConfig';
+export * from './interfaces/EventStoreBusConfig';
+export * from './interfaces/EventTypes';
+export * from './interfaces/SubscriptionTypes';

--- a/src/interfaces/EventStoreBusConfig.ts
+++ b/src/interfaces/EventStoreBusConfig.ts
@@ -1,8 +1,10 @@
 import { EventStoreCatchupSubscriptionConfig, EventStorePersistentSubscriptionConfig } from './SubscriptionTypes';
 import { IEvent } from '@nestjs/cqrs';
 import { TAcknowledgeEventStoreEvent, TEventStoreEvent } from './EventTypes';
+import { EventStoreProjection } from './EventStoreProjection';
 
 export type EventStoreBusConfig = {
+  projections: EventStoreProjection[],
   subscriptions: {
     catchup?: EventStoreCatchupSubscriptionConfig[],
     //volatile? : EventStoreVolatileSubscription[],

--- a/src/interfaces/EventStoreBusConfig.ts
+++ b/src/interfaces/EventStoreBusConfig.ts
@@ -1,0 +1,12 @@
+import { EventStoreCatchupSubscriptionConfig, EventStorePersistentSubscriptionConfig } from './SubscriptionTypes';
+import { IEvent } from '@nestjs/cqrs';
+import { TAcknowledgeEventStoreEvent, TEventStoreEvent } from './EventTypes';
+
+export type EventStoreBusConfig = {
+  subscriptions: {
+    catchup?: EventStoreCatchupSubscriptionConfig[],
+    //volatile? : EventStoreVolatileSubscription[],
+    persistent?: EventStorePersistentSubscriptionConfig[]
+  };
+  eventMapper: (event: TEventStoreEvent | TAcknowledgeEventStoreEvent) => IEvent;
+};

--- a/src/interfaces/EventStoreLibExtension.ts
+++ b/src/interfaces/EventStoreLibExtension.ts
@@ -1,0 +1,10 @@
+import { EventStoreCatchUpSubscription, EventStorePersistentSubscription } from 'node-eventstore-client';
+
+export interface ExtendedCatchUpSubscription extends EventStoreCatchUpSubscription {
+  isLive: boolean | undefined;
+}
+
+export interface ExtendedPersistentSubscription
+  extends EventStorePersistentSubscription {
+  isLive: boolean | undefined;
+}

--- a/src/interfaces/EventStoreProjection.ts
+++ b/src/interfaces/EventStoreProjection.ts
@@ -1,0 +1,11 @@
+import { ProjectionMode } from 'geteventstore-promise';
+
+export type EventStoreProjection = {
+  name: string,
+  content?: string,
+  file?: string,
+  mode?: ProjectionMode,
+  enabled?: boolean,
+  checkPointsEnabled?: boolean,
+  emitEnabled?: boolean,
+};

--- a/src/interfaces/EventTypes.ts
+++ b/src/interfaces/EventTypes.ts
@@ -1,0 +1,74 @@
+import { PersistentSubscriptionNakEventAction } from 'node-eventstore-client';
+import { IEvent } from '@nestjs/cqrs';
+
+export type TEventStoreEvent = {
+  data: {},
+  metadata: {},
+  eventStreamId: string,
+  eventId?: string,
+  created?: Date,
+  eventNumber?: number,
+  eventType?: string,
+  originalEventId?: string,
+};
+
+export type TAcknowledgeEventStoreEvent = TEventStoreEvent & {
+  ack: () => {},
+  nack: (action: PersistentSubscriptionNakEventAction, reason: string) => {}
+}
+
+export class EventStoreEvent implements IEvent {
+  data;
+  metadata;
+  eventId;
+  eventType;
+  eventStreamId;
+  created;
+  eventNumber;
+  /**
+   * If event is resolved u
+   */
+  protected originalEventId;
+
+  constructor(args: TEventStoreEvent) {
+    this.data = args.data;
+    this.metadata = args.metadata;
+    this.eventId = args.eventId;
+    this.eventType = args.eventType ? args.eventType : this.constructor.name.substr(0, -5);
+    this.eventStreamId = args.eventStreamId;
+    this.created = args.created;
+    this.eventNumber = args.eventNumber;
+    this.originalEventId = args.originalEventId;
+  }
+
+  getEventId() {
+    return this.eventId;
+  }
+
+  getEventType() {
+    return this.eventType;
+  }
+
+  getStream() {
+    return this.eventStreamId;
+  }
+
+  getStreamCategory() {
+    return this.eventStreamId.split('-')[0];
+  }
+
+  getStreamId() {
+    return this.eventStreamId.replace(/^[^-]*-/, '');
+  }
+}
+
+export class AcknowledgeEventStoreEvent extends EventStoreEvent {
+  ack;
+  nack;
+
+  constructor(args: TAcknowledgeEventStoreEvent) {
+    super(args);
+    this.ack = args.ack;
+    this.nack = args.nack;
+  }
+}

--- a/src/interfaces/SubscriptionTypes.ts
+++ b/src/interfaces/SubscriptionTypes.ts
@@ -1,0 +1,35 @@
+export type EventStorePersistentSubscriptionConfig = {
+  stream: string;
+  group: string;
+  options?: {
+    resolveLinktos?: boolean,
+    startFrom?: number,
+    extraStatistics?: boolean,
+    messageTimeout?: number,
+    maxRetryCount?: number,
+    liveBufferSize?: number,
+    readBatchSize?: number,
+    historyBufferSize?: number,
+    checkPointAfter?: number,
+    minCheckPointCount?: number,
+    maxCheckPointCount?: number,
+    maxSubscriberCount?: number,
+    namedConsumerStrategy?: 'RoundRobin' | 'DispatchToSingle' | 'Pinned',
+  },
+  autoAck?: boolean | undefined;
+  bufferSize?: number | undefined;
+
+  onSubscriptionDropped?: (
+    sub: EventStorePersistentSubscriptionConfig,
+    reason: string,
+    error: string,
+  ) => void | undefined;
+};
+
+export type EventStoreCatchupSubscriptionConfig = {
+  stream: string;
+};
+// TODO add config for startEvent
+export type EventStoreVolatileSubscription = {
+  stream: string;
+};


### PR DESCRIPTION
Allow creation config for persistent subscriptions and projections.
Read this config on boot and create them before starting to read

Cleanup interfaces in different folders