### PR TITLE
fix error on publishAll with publishAlsoLocally

### DIFF
--- a/src/cqrs/event-store.bus.ts
+++ b/src/cqrs/event-store.bus.ts
@@ -126,7 +126,7 @@ export class EventStoreBus
           _ => {
             // Forward to local event handler and saga
             if (this.config.publishAlsoLocally) {
-              events.forEach(this.subject$.next);
+              events.forEach((event) => this.subject$.next(event));
             }
           },
           err => {


### PR DESCRIPTION
Set the publishAll method with publishAlsoLocally set to true to avoid the error: UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'closed' of undefined