### PR TITLE
Update documentation to run eventstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Event store driven NestJS and CQRS
 example is from official Nest JS example
 
 ```shell script
-docker run -p 22113: -p 11113: -d -n eventstore eventstore/eventstore
+docker run -p 22113:2113 -p 11113:1113 -d --name eventstore eventstore/eventstore --dev --enable-external-tcp --disable-external-tcp-tls --ext-ip=0.0.0.0 --int-ip=0.0.0.0
 yarn
 cd examples
 yarn


### PR DESCRIPTION
Since June 2020, it seems the EventStore default behavior has changed,
hence a new `docker run` command to launch a testing instance for this
project.

See:
https://stackoverflow.com/questions/62341899/trying-to-append-a-stream-event-to-eventstore-throws-exception