### PR TITLE
Override commit(), to please TypeScript typing

### DIFF
--- a/src/cqrs/event-store.aggregate-root.ts
+++ b/src/cqrs/event-store.aggregate-root.ts
@@ -30,4 +30,8 @@ export abstract class EventStoreAggregateRoot extends AggregateRoot {
     // TODO log if not replaced
     return;
   }
+  
+  async commit(): Promise<void> {
+    return super.commit() as unknown as Promise<void>;
+  }
 }


### PR DESCRIPTION
To avoid IDE telling commit() return void,
override it in the middleware class, and change type.