### PR TITLE
[v5.x] Fix unqueue first then publish

### DIFF
--- a/src/cqrs/aggregate-root.ts
+++ b/src/cqrs/aggregate-root.ts
@@ -62,7 +62,10 @@ export abstract class AggregateRoot<EventBase extends IEvent = IEvent> {
 
     // publish the event
     for (const publisher of this.publishers) {
-      await publisher(events);
+      await publisher(events).catch((error) => {
+        this[INTERNAL_EVENTS].unshift(...events);
+        throw error;
+      });
     }
     return this;
   }

--- a/src/cqrs/aggregate-root.ts
+++ b/src/cqrs/aggregate-root.ts
@@ -55,10 +55,15 @@ export abstract class AggregateRoot<EventBase extends IEvent = IEvent> {
         this.publishers.length
       } publishers`,
     );
-    for (const publisher of this.publishers) {
-      await publisher(this.getUncommittedEvents());
-    }
+
+    // flush the queue first to avoid multiple commit of the same event on concurrent calls
+    const events = this.getUncommittedEvents();
     this.clearEvents();
+
+    // publish the event
+    for (const publisher of this.publishers) {
+      await publisher(events);
+    }
     return this;
   }
 


### PR DESCRIPTION
We wait for the publisher to fully push the events before flushing the queue. If concurrent `.commit()` calls are performed this could lead to `IDEMPOTENT WRITE` errors on the eventstore side, leading to unsent events.

This PR aims at flushing the events before sending them to the publisher, drastically reducing error probability.