### PR TITLE
v4.x: Cannot handle events when not resolved

### DIFF
--- a/src/event-store/event-store.service.ts
+++ b/src/event-store/event-store.service.ts
@@ -195,16 +195,7 @@ export class EventStoreService implements OnModuleDestroy, OnModuleInit {
     }
     // use default onEvent
     const { event } = payload;
-    // TODO allow unresolved event
-    if (!payload.isResolved) {
-      this.logger.warn(
-        `Ignore unresolved event from stream ${payload.originalStreamId}[${event.eventNumber.low}] with ID ${payload.originalEvent.eventId}`,
-      );
-      if (!subscription._autoAck && subscription.hasOwnProperty('_autoAck')) {
-        await subscription.acknowledge([payload]);
-      }
-      return;
-    }
+    
     // TODO handle not JSON
     if (!event.isJson) {
       // TODO add info on error not coded


### PR DESCRIPTION
When subscribing to direct stream (the one where the event is posted), the event is not resolved as a link (so isResolved === false)
Must skip that check.