### PR TITLE
Fix/write event bus config and publish bug

### DIFF
--- a/src/cqrs-event-store.module.ts
+++ b/src/cqrs-event-store.module.ts
@@ -62,7 +62,10 @@ export class CqrsEventStoreModule extends CqrsModule {
         { provide: READ_EVENT_BUS_CONFIG, useValue: eventBusConfig.read },
         {
           provide: WRITE_EVENT_BUS_CONFIG,
-          useValue: { ...getDefaultEventBusConfiguration, ...eventBusConfig },
+          useValue: {
+            ...getDefaultEventBusConfiguration,
+            ...eventBusConfig.write,
+          },
         },
       ],
       exports: [EventStoreModule],

--- a/src/cqrs/write-event-bus.ts
+++ b/src/cqrs/write-event-bus.ts
@@ -53,7 +53,7 @@ export class WriteEventBus<
       throw new InvalidEventException(validated);
     }
     return await this.publisher.publish<T>(
-      preparedEvents,
+      preparedEvents[0],
       // @ts-ignore
       context,
     );


### PR DESCRIPTION
### Bug 1

The WriteEventBus class has a bug were the publish function call the parent with an array of "preparedEvents" but since is the single event publish function we shoud do the same as we do on ReadEventBus.

https://github.com/PrestaShopCorp/nestjs-geteventstore/blob/3a14375624d53521fa3aad698c6729f1234dbf59/src/cqrs/write-event-bus.ts#L56

https://github.com/PrestaShopCorp/nestjs-geteventstore/blob/3a14375624d53521fa3aad698c6729f1234dbf59/src/cqrs/read-event-bus.ts#L35

### Bug 2

The configuration provider defined for the WriteEventBus configuration had a  bug and registered the whole configuration instead causing a bug here regarding the use of the serviceName as stream name.

https://github.com/PrestaShopCorp/nestjs-geteventstore/blob/d2c482ab84c85ef30daea029f07bb4f12fd20ae5/src/event-store/publisher/event-store.publisher.ts#L76
